### PR TITLE
Use Timeout.timeout

### DIFF
--- a/lib/prefork_engine.rb
+++ b/lib/prefork_engine.rb
@@ -160,7 +160,7 @@ class PreforkEngine
     }
     if timeout > 0
       begin
-       timeout(timeout){
+       Timeout.timeout(timeout){
          wait_loop.call
        }
      rescue Timeout::Error


### PR DESCRIPTION
it shows "Object#timeout is deprecated, use Timeout.timeout instead."
